### PR TITLE
Add evpn_rd_type & evpn_rt_type

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -759,6 +759,29 @@ l2leaf:
 mlag_ibgp_peering_vrfs:
   base_vlan: < 1-4000 | default -> 3000 >
 
+# Specify RD type | Optional
+# Route Distinguisher (RD) for L2 / L3 services is set to <overlay_loopback>:<vni> per default.
+# By configuring evpn_rd_type the Administrator subfield (first part of RD) can be set to other values.
+#
+# Note:
+# RD is a 48-bit value which is split into <16-bit>:<32-bit> or <32-bit>:<16-bit>.
+# For loopback or 32-bit ASN/number the VNI can only be a 16-bit number.
+# For 16-bit ASN/number the VNI can be a 32-bit number.
+evpn_rd_type:
+  admin_subfield: < "overlay_loopback" | "vtep_loopback" | "asn" | "spine_asn" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> "overlay_loopback" >
+
+# Specify RT type | Optional
+# Route Target (RT) for L2 / L3 services is set to <vni>:<vni> per default
+# By configuring evpn_rt_type the Administrator subfield (first part of RT) can be set to other values.
+#
+# Note:
+# RT is a 48-bit value which is split into <16-bit>:<32-bit> or <32-bit>:<16-bit>.
+# For 32-bit ASN/number the VNI can only be a 16-bit number.
+# For 16-bit ASN/number the VNI can be a 32-bit number.
+evpn_rt_type:
+  admin_subfield: < "asn" | "spine_asn" | "vni" | <0-65535> | <0-2147483647> | default -> "vni" >
+
+
 # Dictionary of tenants, to define network services: L3 VRFs and L2 VLNAS.
 
 tenants:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -779,7 +779,7 @@ evpn_rd_type:
 # For 32-bit ASN/number the VNI can only be a 16-bit number.
 # For 16-bit ASN/number the VNI can be a 32-bit number.
 evpn_rt_type:
-  admin_subfield: < "asn" | "spine_asn" | "vni" | <0-65535> | <0-2147483647> | default -> "vni" >
+  admin_subfield: < "asn" | "spine_asn" | "vni" | <0-65535> | <0-4294967295> | default -> "vni" >
 
 
 # Dictionary of tenants, to define network services: L3 VRFs and L2 VLNAS.

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -123,6 +123,42 @@
 {%     endif %}
 {% endfor %}
 {% set leaf.vrfs = leaf.vrfs | unique  %}
+{# Setting evpn_rd_admin_subfield #}
+{% set leaf.evpn_rd_admin_subfield = overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) %}
+{% if evpn_rd_type is defined and evpn_rd_type is not none %}
+{%     if evpn_rd_type.admin_subfield is defined and evpn_rd_type.admin_subfield is not none %}
+{%         if evpn_rd_type.admin_subfield == "vtep_loopback" %}
+{%             if leaf.mlag == true and leaf.mlag_role == "primary" %}
+{%                 set leaf.evpn_rd_admin_subfield = vtep_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) %}
+{%             elif leaf.mlag == true and leaf.mlag_role == "secondary" %}
+{%                 set leaf.evpn_rd_admin_subfield = vtep_loopback_network_summary | ipaddr('network') | ipmath(leaf.mlag_peer_id + spine.nodes | length) %}
+{%             else %}
+{%                 set leaf.evpn_rd_admin_subfield = vtep_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) %}
+{%             endif %}
+{%         elif evpn_rd_type.admin_subfield == "asn" %}
+{%             set leaf.evpn_rd_admin_subfield = leaf.bgp_as %}
+{%         elif evpn_rd_type.admin_subfield == "spine_asn" %}
+{%             set leaf.evpn_rd_admin_subfield = spine.bgp_as %}
+{%         elif evpn_rd_type.admin_subfield | ipaddr %}
+{%             set leaf.evpn_rd_admin_subfield = evpn_rd_type.admin_subfield %}
+{%         elif evpn_rd_type.admin_subfield is number and evpn_rd_type.admin_subfield >= 0 and evpn_rd_type.admin_subfield <= 4294967295 %}
+{%             set leaf.evpn_rd_admin_subfield = evpn_rd_type.admin_subfield %}
+{%         endif %}
+{%     endif %}
+{% endif %}
+{# Setting evpn_rt_admin_subfield #}
+{% set leaf.evpn_rt_admin_subfield = false %}
+{% if evpn_rt_type is defined and evpn_rt_type is not none %}
+{%     if evpn_rt_type.admin_subfield is defined and evpn_rt_type.admin_subfield is not none %}
+{%         if evpn_rt_type.admin_subfield == "asn" %}
+{%             set leaf.evpn_rt_admin_subfield = leaf.bgp_as %}
+{%         elif evpn_rt_type.admin_subfield == "spine_asn" %}
+{%             set leaf.evpn_rt_admin_subfield = spine.bgp_as %}
+{%         elif evpn_rt_type.admin_subfield is number and evpn_rt_type.admin_subfield >= 0 and evpn_rt_type.admin_subfield <= 4294967295 %}
+{%             set leaf.evpn_rt_admin_subfield = evpn_rt_type.admin_subfield %}
+{%         endif %}
+{%     endif %}
+{% endif %}
 
 ### Leaf Info ###
 l3leaf_node_group: {{ leaf.group }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
@@ -5,10 +5,10 @@
 {%         if tenants[tenant].vrfs is defined %}
 {%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
     {{ vrf }}:
-      rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
+      rd: "{{ leaf.evpn_rd_admin_subfield }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
       route_targets:
         both:
-          - "{{ tenants[tenant].vrfs[vrf].vrf_vni }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
+          - "{{ leaf.evpn_rt_admin_subfield or tenants[tenant].vrfs[vrf].vrf_vni }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
       redistribute_routes:
         - learned
 {%                 set vlan_range = [] %}
@@ -21,20 +21,17 @@
 {%         if tenants[tenant].l2vlans is defined %}
 {%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
 {%                 set l2vlan_int = l2vlan | int %}
+{%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
+{%                     set vni = tenants[tenant].l2vlans[l2vlan].vni_override %}
+{%                 else %}
+{%                     set vni = tenants[tenant].mac_vrf_vni_base + l2vlan_int %}
+{%                 endif %}
     {{ tenants[tenant].l2vlans[l2vlan].name }}:
       tenant: {{ tenant }}
-{%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
-      rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].l2vlans[l2vlan].vni_override }}"
-{%                 else %}
-      rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].mac_vrf_vni_base + l2vlan_int }}"
-{%                 endif %}
+      rd: "{{ leaf.evpn_rd_admin_subfield }}:{{ vni }}"
       route_targets:
         both:
-{%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
-          - "{{ tenants[tenant].l2vlans[l2vlan].vni_override }}:{{ tenants[tenant].l2vlans[l2vlan].vni_override }}"
-{%                 else %}
-          - "{{ tenants[tenant].mac_vrf_vni_base + l2vlan }}:{{ tenants[tenant].mac_vrf_vni_base + l2vlan_int }}"
-{%                 endif %}
+          - "{{ leaf.evpn_rt_admin_subfield or vni }}:{{ vni }}"
       redistribute_routes:
         - learned
       vlan: {{ l2vlan_int }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
@@ -6,20 +6,17 @@
 {%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi in leaf.svis %}
 {%                      set svi_int = svi | int %}
+{%                     if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
+{%                         set vni = tenants[tenant].vrfs[vrf].svis[svi].vni_override %}
+{%                     else %}
+{%                         set vni = tenants[tenant].mac_vrf_vni_base + svi_int %}
+{%                     endif %}
     {{ svi }}:
       tenant: {{ tenant }}
-{%                     if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
-      rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].vrfs[vrf].svis[svi].vni_override }}"
-{%                     else %}
-      rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].mac_vrf_vni_base + svi_int }}"
-{%                     endif %}
+      rd: "{{ leaf.evpn_rd_admin_subfield }}:{{ vni }}"
       route_targets:
         both:
-{%                     if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
-          - "{{ tenants[tenant].vrfs[vrf].svis[svi].vni_override }}:{{ tenants[tenant].vrfs[vrf].svis[svi].vni_override }}"
-{%                     else %}
-          - "{{ tenants[tenant].mac_vrf_vni_base + svi }}:{{ tenants[tenant].mac_vrf_vni_base + svi_int }}"
-{%                     endif %}
+          - "{{ leaf.evpn_rt_admin_subfield or vni }}:{{ vni }}"
       redistribute_routes:
         - learned
 {%                 endfor %}
@@ -28,20 +25,17 @@
 {%         if tenants[tenant].l2vlans is defined %}
 {%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
 {%                 set l2vlan_int = l2vlan | int %}
+{%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
+{%                     set vni = tenants[tenant].l2vlans[l2vlan].vni_override %}
+{%                 else %}
+{%                     set vni = tenants[tenant].mac_vrf_vni_base + l2vlan_int %}
+{%                 endif %}
     {{ l2vlan }}:
       tenant: {{ tenant }}
-{%                     if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
-      rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].l2vlans[l2vlan].vni_override }}"
-{%                     else %}
-      rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].mac_vrf_vni_base + l2vlan_int }}"
-{%                     endif %}
+      rd: "{{ leaf.evpn_rd_admin_subfield }}:{{ vni }}"
       route_targets:
         both:
-{%                     if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
-          - "{{ tenants[tenant].l2vlans[l2vlan].vni_override }}:{{ tenants[tenant].l2vlans[l2vlan].vni_override }}"
-{%                     else %}
-          - "{{ tenants[tenant].mac_vrf_vni_base + l2vlan }}:{{ tenants[tenant].mac_vrf_vni_base + l2vlan_int }}"
-{%                     endif %}
+          - "{{ leaf.evpn_rt_admin_subfield or vni }}:{{ vni }}"
       redistribute_routes:
         - learned
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
@@ -5,14 +5,14 @@
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
     {{ vrf }}:
       router_id: {{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}
-      rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
+      rd: "{{ leaf.evpn_rd_admin_subfield }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
       route_targets:
         import:
           evpn:
-            - "{{ tenants[tenant].vrfs[vrf].vrf_vni }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
+            - "{{ leaf.evpn_rt_admin_subfield or tenants[tenant].vrfs[vrf].vrf_vni }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
         export:
           evpn:
-            - "{{ tenants[tenant].vrfs[vrf].vrf_vni }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
+            - "{{ leaf.evpn_rt_admin_subfield or tenants[tenant].vrfs[vrf].vrf_vni }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
 {%             if leaf.mlag == true %}
       neighbors:
         {{ mlag_ips.leaf_peer_l3 | ipaddr('network') | ipmath(leaf.mlag_peer_ip) }}:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
Add knobs to allow custom RD and RT types.
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
Adding group_vars "evpn_rd_type" & "evpn_rt_type" to allow various styles of route distinguisher and route target.
This will also allow support for VNI numbers > 65535 in case admin_subfield is only 16-bits.

```yaml
 evpn_rd_type:
   admin_subfield: < "overlay_loopback" | "vtep_loopback" | "asn" | "spine_asn" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> "overlay_loopback" >
 evpn_rt_type:
   admin_subfield: < "asn" | "spine_asn" | "vni" | <0-65535> | <0-4294967295> | default -> "vni" >
```

Readme.md for eos_l3ls_evpn role has also been updated.

No update to generated documentation since services are not included in documentation.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

### Common service configuration:
DC1_TENANTS_NETWORKS.yml (in group_vars)
```yaml
tenants:
  # Tenant A Specific Information - VRFs / VLANs
  Tenant_A:
    mac_vrf_vni_base: 10000
    vrfs:
      Common_VRF:
        vrf_vni: 10
        vtep_diagnostic:
          loopback: 100
          loopback_ip_range: 10.255.1.0/24
        svis:
          12:
            name: Tenant_A_OP_Zone_Test
            tags: [opzone]
            enabled: true
            ip_subnet: 172.16.112.0/24
            mtu: 9000
<...>
```
### Test 1
DC1_FABRIC.yml (in group_vars)
With default settings or
```yaml
evpn_rd_type:
evpn_rt_type:
```
or
```yaml
evpn_rd_type:
  admin_subfield:
evpn_rt_type:
  admin_subfield:
```
Result:
```eos
   vlan 12
      rd 192.168.255.3:10012
      route-target both 10012:10012
      redistribute learned
<...>
   vrf Common_VRF
      rd 192.168.255.3:10
      route-target import evpn 10:10
      route-target export evpn 10:10
      router-id 192.168.255.3
      neighbor 10.255.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
      redistribute connected
```
### Test 2
DC1_FABRIC.yml (in group_vars)
```yaml
evpn_rd_type:
  admin_subfield: vtep_loopback
evpn_rt_type:
  admin_subfield: asn
```
Result:
```eos
   vlan 12
      rd 192.168.254.3:10012
      route-target both 65101:10012
      redistribute learned
<...>
   vrf Common_VRF
      rd 192.168.254.3:10
      route-target import evpn 65101:10
      route-target export evpn 65101:10
      router-id 192.168.255.3
      neighbor 10.255.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
      redistribute connected
```
### Test 3
DC1_FABRIC.yml (in group_vars)
```yaml
evpn_rd_type:
  admin_subfield: asn
evpn_rt_type:
  admin_subfield: spine_asn
```
Result:
```eos
   vlan 12
      rd 65101:10012
      route-target both 65001:10012
      redistribute learned
<...>
   vrf Common_VRF
      rd 65101:10
      route-target import evpn 65001:10
      route-target export evpn 65001:10
      router-id 192.168.255.3
      neighbor 10.255.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
      redistribute connected
```
### Test 4
DC1_FABRIC.yml (in group_vars)
```yaml
evpn_rd_type:
  admin_subfield: spine_asn
evpn_rt_type:
  admin_subfield: 1234
```
Result:
```eos
   vlan 12
      rd 65001:10012
      route-target both 1234:10012
      redistribute learned
<...>
   vrf Common_VRF
      rd 65001:10
      route-target import evpn 1234:10
      route-target export evpn 1234:10
      router-id 192.168.255.3
      neighbor 10.255.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
      redistribute connected
```
### Test 5
DC1_FABRIC.yml (in group_vars)
```yaml
evpn_rd_type:
  admin_subfield: 1.2.3.4
evpn_rt_type:
  admin_subfield: 12341234
```
Result:
```eos
   vlan 12
      rd 1.2.3.4:10012
      route-target both 12341234:10012
      redistribute learned
<...>
   vrf Common_VRF
      rd 1.2.3.4:10
      route-target import evpn 12341234:10
      route-target export evpn 12341234:10
      router-id 192.168.255.3
      neighbor 10.255.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
      redistribute connected
```
### Test 6
DC1_FABRIC.yml (in group_vars)
```yaml
evpn_rd_type:
  admin_subfield: 1234
evpn_rt_type:
  admin_subfield: vni
```
Result:
```eos
   vlan 12
      rd 1234:10012
      route-target both 10012:10012
      redistribute learned
<...>
   vrf Common_VRF
      rd 1234:10
      route-target import evpn 10:10
      route-target export evpn 10:10
      router-id 192.168.255.3
      neighbor 10.255.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
      redistribute connected
```
### Test 7
DC1_FABRIC.yml (in group_vars)
```yaml
evpn_rd_type:
  admin_subfield: 12341234
evpn_rt_type:
  admin_subfield: invalid_value
```
Result:
```eos
   vlan 12
      rd 12341234:10012
      route-target both 10012:10012
      redistribute learned
<...>
   vrf Common_VRF
      rd 12341234:10
      route-target import evpn 10:10
      route-target export evpn 10:10
      router-id 192.168.255.3
      neighbor 10.255.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
      redistribute connected
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
