### PR TITLE
Test: Add test for breaking change

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dc1-l2-child-asymmetric.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dc1-l2-child-asymmetric.cfg
@@ -1,0 +1,77 @@
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+no enable password
+no aaa root
+!
+no username admin
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname dc1-l2-child-asymmetric
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+ip name-server vrf MGMT 2001:db8::1
+ip name-server vrf MGMT 2001:db8::2
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE dc1-l2-child-asymmetric
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 16384
+!
+vlan 3902
+   name PARENT_B_ONLY
+!
+vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+interface Port-Channel1
+   description DC1-L2-PARENT-A_Po1
+   no shutdown
+   switchport trunk allowed vlan 3902
+   switchport mode trunk
+   switchport
+!
+interface Ethernet1
+   description DC1-L2-PARENT-A_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description DC1-L2-PARENT-B_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Management1
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.134/24
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+ntp server vrf MGMT 2001:db8::3
+!
+end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dc1-l2-parent-a.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dc1-l2-parent-a.cfg
@@ -1,0 +1,75 @@
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+no enable password
+no aaa root
+!
+no username admin
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname dc1-l2-parent-a
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+ip name-server vrf MGMT 2001:db8::1
+ip name-server vrf MGMT 2001:db8::2
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE dc1-l2-parent-a
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 16384
+!
+vlan 3901
+   name PARENT_A_ONLY
+!
+vlan 3902
+   name PARENT_B_ONLY
+!
+vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+interface Port-Channel1
+   description DC1-L2-CHILD-ASYMMETRIC_Po1
+   no shutdown
+   switchport trunk allowed vlan 3902
+   switchport mode trunk
+   switchport
+!
+interface Ethernet1
+   description DC1-L2-CHILD-ASYMMETRIC_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Management1
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.132/24
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+ntp server vrf MGMT 2001:db8::3
+!
+end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dc1-l2-parent-b.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dc1-l2-parent-b.cfg
@@ -1,0 +1,72 @@
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+no enable password
+no aaa root
+!
+no username admin
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname dc1-l2-parent-b
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+ip name-server vrf MGMT 2001:db8::1
+ip name-server vrf MGMT 2001:db8::2
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE dc1-l2-parent-b
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 16384
+!
+vlan 3902
+   name PARENT_B_ONLY
+!
+vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+interface Port-Channel1
+   description DC1-L2-CHILD-ASYMMETRIC_Po1
+   no shutdown
+   switchport trunk allowed vlan 3902
+   switchport mode trunk
+   switchport
+!
+interface Ethernet1
+   description DC1-L2-CHILD-ASYMMETRIC_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Management1
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.133/24
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+ntp server vrf MGMT 2001:db8::3
+!
+end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-l2-child-asymmetric.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-l2-child-asymmetric.yml
@@ -1,0 +1,124 @@
+aaa_root:
+  disabled: true
+boot:
+  secret:
+    key: a153de6290ff1409257ade45f
+config_end: true
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.200.11:9910
+  cvauth:
+    method: token
+    token_file: /tmp/token
+  cvvrf: MGMT
+  disable_aaa: false
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+enable_password:
+  disabled: true
+ethernet_interfaces:
+- name: Ethernet1
+  description: DC1-L2-PARENT-A_Ethernet1
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+  metadata:
+    peer: dc1-l2-parent-a
+    peer_interface: Ethernet1
+    peer_type: l2leaf
+- name: Ethernet2
+  description: DC1-L2-PARENT-B_Ethernet1
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+  metadata:
+    peer: dc1-l2-parent-b
+    peer_interface: Ethernet1
+    peer_type: l2leaf
+hostname: dc1-l2-child-asymmetric
+ip_igmp_snooping:
+  globally_enabled: true
+ip_name_server:
+  vrfs:
+  - name: MGMT
+    servers:
+    - ip_address: 192.168.200.5
+    - ip_address: 8.8.8.8
+    - ip_address: 2001:db8::1
+    - ip_address: 2001:db8::2
+local_users:
+- name: admin
+  disabled: true
+- name: cvpadmin
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+  ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU=
+    cvpadmin@hostmachine.local
+  secondary_ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz=
+    cvpadmin@hostmachine.local
+management_api_http:
+  enable_https: true
+  default_services: false
+  enable_vrfs:
+  - name: MGMT
+management_interfaces:
+- name: Management1
+  description: OOB_MANAGEMENT
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.134/24
+  type: oob
+  gateway: 192.168.200.5
+metadata:
+  is_deployed: true
+  platform: vEOS-LAB
+  rack: rackE
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+ntp:
+  local_interface:
+    name: Management1
+    vrf: MGMT
+  servers:
+  - name: 192.168.200.5
+    preferred: true
+  - name: 2001:db8::3
+  vrf: MGMT
+port_channel_interfaces:
+- name: Port-Channel1
+  description: DC1-L2-PARENT-A_Po1
+  shutdown: false
+  switchport:
+    enabled: true
+    mode: trunk
+    trunk:
+      allowed_vlan: '3902'
+service_routing_protocols_model: multi-agent
+snmp_server:
+  contact: example@example.com
+  location: EOS_DESIGNS_UNIT_TESTS rackE dc1-l2-child-asymmetric
+spanning_tree:
+  mode: mstp
+  mst_instances:
+  - id: '0'
+    priority: 16384
+static_routes:
+- vrf: MGMT
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
+transceiver_qsfp_default_mode_4x10: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vlans:
+- id: 3902
+  name: PARENT_B_ONLY
+  metadata:
+    tenants:
+    - Tenant_PARENT_B
+vrfs:
+- name: MGMT
+  ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-l2-parent-a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-l2-parent-a.yml
@@ -1,0 +1,119 @@
+aaa_root:
+  disabled: true
+boot:
+  secret:
+    key: a153de6290ff1409257ade45f
+config_end: true
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.200.11:9910
+  cvauth:
+    method: token
+    token_file: /tmp/token
+  cvvrf: MGMT
+  disable_aaa: false
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+enable_password:
+  disabled: true
+ethernet_interfaces:
+- name: Ethernet1
+  description: DC1-L2-CHILD-ASYMMETRIC_Ethernet1
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+  metadata:
+    peer: dc1-l2-child-asymmetric
+    peer_interface: Ethernet1
+    peer_type: l2leaf
+hostname: dc1-l2-parent-a
+ip_igmp_snooping:
+  globally_enabled: true
+ip_name_server:
+  vrfs:
+  - name: MGMT
+    servers:
+    - ip_address: 192.168.200.5
+    - ip_address: 8.8.8.8
+    - ip_address: 2001:db8::1
+    - ip_address: 2001:db8::2
+local_users:
+- name: admin
+  disabled: true
+- name: cvpadmin
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+  ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU=
+    cvpadmin@hostmachine.local
+  secondary_ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz=
+    cvpadmin@hostmachine.local
+management_api_http:
+  enable_https: true
+  default_services: false
+  enable_vrfs:
+  - name: MGMT
+management_interfaces:
+- name: Management1
+  description: OOB_MANAGEMENT
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.132/24
+  type: oob
+  gateway: 192.168.200.5
+metadata:
+  is_deployed: true
+  platform: vEOS-LAB
+  rack: rackE
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+ntp:
+  local_interface:
+    name: Management1
+    vrf: MGMT
+  servers:
+  - name: 192.168.200.5
+    preferred: true
+  - name: 2001:db8::3
+  vrf: MGMT
+port_channel_interfaces:
+- name: Port-Channel1
+  description: DC1-L2-CHILD-ASYMMETRIC_Po1
+  shutdown: false
+  switchport:
+    enabled: true
+    mode: trunk
+    trunk:
+      allowed_vlan: '3902'
+service_routing_protocols_model: multi-agent
+snmp_server:
+  contact: example@example.com
+  location: EOS_DESIGNS_UNIT_TESTS rackE dc1-l2-parent-a
+spanning_tree:
+  mode: mstp
+  mst_instances:
+  - id: '0'
+    priority: 16384
+static_routes:
+- vrf: MGMT
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
+transceiver_qsfp_default_mode_4x10: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vlans:
+- id: 3901
+  name: PARENT_A_ONLY
+  metadata:
+    tenants:
+    - Tenant_PARENT_A
+- id: 3902
+  name: PARENT_B_ONLY
+  metadata:
+    tenants:
+    - Tenant_PARENT_B
+vrfs:
+- name: MGMT
+  ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-l2-parent-b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dc1-l2-parent-b.yml
@@ -1,0 +1,114 @@
+aaa_root:
+  disabled: true
+boot:
+  secret:
+    key: a153de6290ff1409257ade45f
+config_end: true
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.200.11:9910
+  cvauth:
+    method: token
+    token_file: /tmp/token
+  cvvrf: MGMT
+  disable_aaa: false
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+enable_password:
+  disabled: true
+ethernet_interfaces:
+- name: Ethernet1
+  description: DC1-L2-CHILD-ASYMMETRIC_Ethernet2
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+  metadata:
+    peer: dc1-l2-child-asymmetric
+    peer_interface: Ethernet2
+    peer_type: l2leaf
+hostname: dc1-l2-parent-b
+ip_igmp_snooping:
+  globally_enabled: true
+ip_name_server:
+  vrfs:
+  - name: MGMT
+    servers:
+    - ip_address: 192.168.200.5
+    - ip_address: 8.8.8.8
+    - ip_address: 2001:db8::1
+    - ip_address: 2001:db8::2
+local_users:
+- name: admin
+  disabled: true
+- name: cvpadmin
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+  ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU=
+    cvpadmin@hostmachine.local
+  secondary_ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz=
+    cvpadmin@hostmachine.local
+management_api_http:
+  enable_https: true
+  default_services: false
+  enable_vrfs:
+  - name: MGMT
+management_interfaces:
+- name: Management1
+  description: OOB_MANAGEMENT
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.133/24
+  type: oob
+  gateway: 192.168.200.5
+metadata:
+  is_deployed: true
+  platform: vEOS-LAB
+  rack: rackE
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+ntp:
+  local_interface:
+    name: Management1
+    vrf: MGMT
+  servers:
+  - name: 192.168.200.5
+    preferred: true
+  - name: 2001:db8::3
+  vrf: MGMT
+port_channel_interfaces:
+- name: Port-Channel1
+  description: DC1-L2-CHILD-ASYMMETRIC_Po1
+  shutdown: false
+  switchport:
+    enabled: true
+    mode: trunk
+    trunk:
+      allowed_vlan: '3902'
+service_routing_protocols_model: multi-agent
+snmp_server:
+  contact: example@example.com
+  location: EOS_DESIGNS_UNIT_TESTS rackE dc1-l2-parent-b
+spanning_tree:
+  mode: mstp
+  mst_instances:
+  - id: '0'
+    priority: 16384
+static_routes:
+- vrf: MGMT
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
+transceiver_qsfp_default_mode_4x10: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vlans:
+- id: 3902
+  name: PARENT_B_ONLY
+  metadata:
+    tenants:
+    - Tenant_PARENT_B
+vrfs:
+- name: MGMT
+  ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -537,6 +537,40 @@ l2leaf:
           filter:
             only_vlans_in_use: true
 
+    # Minimal topology for asymmetric parent VLAN availability across split port-channel parents.
+    # Parent A has VLANs 3901 and 3902, parent B has only VLAN 3902, and the child has both VLANs.
+    # In devel the split port-channel allowed VLANs were calculated per uplink parent, so the child and
+    # parent A rendered 3901-3902 while parent B rendered 3902. This PR filters VLANs against all parent
+    # paths, so all three devices render 3902.
+    - group: DC1_L2LEAF9
+      mlag: false
+      uplink_type: port-channel
+      nodes:
+        - name: dc1-l2-parent-a
+          mgmt_ip: 192.168.200.132/24
+          uplink_interfaces: []
+          uplink_switches: []
+          uplink_switch_interfaces: []
+          filter:
+            tenants: [Tenant_PARENT_A, Tenant_PARENT_B]
+            tags: [parent-a, parent-b]
+        - name: dc1-l2-parent-b
+          mgmt_ip: 192.168.200.133/24
+          uplink_interfaces: []
+          uplink_switches: []
+          uplink_switch_interfaces: []
+          filter:
+            tenants: [Tenant_PARENT_B]
+            tags: [parent-b]
+        - name: dc1-l2-child-asymmetric
+          mgmt_ip: 192.168.200.134/24
+          uplink_interfaces: [Ethernet1, Ethernet2]
+          uplink_switches: [dc1-l2-parent-a, dc1-l2-parent-b]
+          uplink_switch_interfaces: [Ethernet1, Ethernet1]
+          filter:
+            tenants: [Tenant_PARENT_A, Tenant_PARENT_B]
+            tags: [parent-a, parent-b]
+
 # Update p2p mtu 9000 -> 1500
 p2p_uplinks_mtu: 1500
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_L2LEAF9.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_L2LEAF9.yml
@@ -1,0 +1,14 @@
+---
+tenant_parent_a:
+  - name: Tenant_PARENT_A
+    l2vlans:
+      - id: 3901
+        name: PARENT_A_ONLY
+        tags: [parent-a]
+
+tenant_parent_b:
+  - name: Tenant_PARENT_B
+    l2vlans:
+      - id: 3902
+        name: PARENT_B_ONLY
+        tags: [parent-b]

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/main.yml
@@ -74,3 +74,5 @@ network_services_keys:
   - name: tenant_b
   - name: tenant_c
   - name: tenant_d
+  - name: tenant_parent_a
+  - name: tenant_parent_b

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -78,6 +78,11 @@ all:
                         dc1-l2leaf8e:
                         dc1-l2leaf8f:
                         dc1-l2leaf8g:
+                    DC1_L2LEAF9:
+                      hosts:
+                        dc1-l2-child-asymmetric:
+                        dc1-l2-parent-a:
+                        dc1-l2-parent-b:
                     TESTS:
                       hosts:
                         mgmt-interface-default:


### PR DESCRIPTION
this PR shows a change of behavior between devel and the PR code because of the way of how we used to filter VLANs per uplink. There are other weirder cases:

Parent A: 3901
Parent B: 3902
child: 3901, 3902

devel -> 3901 on child and parentA and 3902 on parent B
PR -> None on all

